### PR TITLE
HTM-Val 2024

### DIFF
--- a/policyer/policy_for_tackverksamhet.tex
+++ b/policyer/policy_for_tackverksamhet.tex
@@ -95,8 +95,6 @@ Subventionering av arbetskläder motsvarande 350 kr ges till funktionärer som h
   \begin{itemize}
     \item Informationsansvarig
     \item Vice Informationsansvarig
-    \item Dwww-ansvarig
-    \item Webmaster
   \end{itemize}
   \subsubsection*{Nollningsutskottet}
   \begin{itemize}
@@ -116,8 +114,6 @@ Subventionering av arbetskläder motsvarande 350 kr ges till funktionärer som h
   \begin{itemize}
     \item Källarmästare
     \item Vice Källarmästare
-    \item Root
-    \item Vice root
   \end{itemize}
   \subsubsection*{Trivselrådet}
   \begin{itemize}
@@ -161,6 +157,14 @@ Subventionering av arbetskläder motsvarande 350 kr ges till funktionärer som h
     \item Tackmästare
   \end{itemize}
 
+  \subsubsection*{Centralprocessutskottet}
+  \begin{itemize}
+    \item Processmästare
+    \item Vice Processmästare
+    \item DWWW-ansvarig
+    \item root
+  \end{itemize}
+  
   \subsubsection*{Medaljelelekommittén}
   \begin{itemize}
     \item Övermarskalk

--- a/policyer/policy_for_val.tex
+++ b/policyer/policy_for_val.tex
@@ -128,12 +128,6 @@ vidare.
         \item Medlem i projektgruppen för Teknikfokus
     \end{itemize}
 
-    \subsubsection*{Källarmästeriet}
-    \begin{itemize}
-        \item Sudo
-        \item Root
-        \item Vice root
-    \end{itemize}
 
     \subsubsection*{Aktivitetsutskottet}
     \begin{itemize}
@@ -143,10 +137,6 @@ vidare.
         \item Shopaholic
     \end{itemize}
 
-    \subsubsection*{Informationsutskottet}
-    \begin{itemize}
-        \item DWWW-ansvarig
-    \end{itemize}
 
     \subsubsection*{Sexmästeriet}
     \begin{itemize}
@@ -178,6 +168,13 @@ vidare.
     \begin{itemize}
         \item Jubileumsansvarig
     \end{itemize}
+
+    \subsubsection*{Centralprocessutskottet}
+    \begin{itemize}
+        \item DWWW-ansvarig
+        \item root
+        \item Utvecklare
+    \end{itemize}
 \end{multicols}
 
 \pagebreak
@@ -194,9 +191,6 @@ vidare.
 
     \subsubsection*{Källarmästeriet}
     \begin{itemize}
-        \item Root
-        \item Vice root
-        \item Sudo
         \item Trädgårdsmästare
         \item Bilansvarig
     \end{itemize}
@@ -208,10 +202,6 @@ vidare.
         \item Shopaholic
     \end{itemize}
 
-    \subsubsection*{Informationsutskottet}
-    \begin{itemize}
-        \item DWWW-ansvarig
-    \end{itemize}
 
     \subsubsection*{Sexmästeriet}
     \begin{itemize}
@@ -236,6 +226,14 @@ vidare.
     \begin{itemize}
         \item Framtidsledamot
     \end{itemize}
+
+    \subsubsection*{Centralprocessutskottet}
+    \begin{itemize}
+    \item DWWW-ansvarig
+    \item root
+    \item Utvecklare
+    \end{itemize}
+    
 \end{multicols}
 
 \subsubsection*{Poster som bör väljas innan läsårets start}

--- a/reglemente/reglemente.tex
+++ b/reglemente/reglemente.tex
@@ -180,6 +180,7 @@ kan sträcka sig över flera år och ska varje år ha en konkret motsvarighet i 
 		\item Näringslivsansvarig (1)
 		\item Källarmästare (1)
 		\item Aktivitetsansvarig (1)
+        \item Processmästare (1)
 		\item Vice Informationsansvarig (1)
 		\item Vice Skattmästare (1)
 		\item Vice Cafémästare (1)
@@ -188,6 +189,7 @@ kan sträcka sig över flera år och ska varje år ha en konkret motsvarighet i 
 		\item Vice Näringslivsansvarig (1)
 		\item Vice Källarmästare (1)
 		\item Vice Aktivitetsansvarig (1)
+        \item Vice Processmästare (1)
 		\item Revisor (2)
 		\item Inspektor (1)
 		\item Framtidsordförande (1)
@@ -243,8 +245,7 @@ kan sträcka sig över flera år och ska varje år ha en konkret motsvarighet i 
 
 	\item[Sammanträde]
 	Sektionsstyrelsen sammanträder på kallelse av ordförande eller vid dennes frånvaro av vice ordförande. Ständigt adjungerad är, förutom de av stadgan och reglementet fastställda, även E-sektionens
-	ordförande, två styrelseledarmöter från D-chip, sektionens kårkontakter, Trivselmästaren
-	samt Framtidsordförande.
+	ordförande, två styrelseledarmöter från D-chip, sektionens kårkontakter, Trivselmästaren, Framtidsordförande samt Processmästaren.
 
 \end{reglemlista}
 
@@ -381,10 +382,9 @@ kan sträcka sig över flera år och ska varje år ha en konkret motsvarighet i 
 	\item[Åligganden]
 	Det åligger källarmästeriet
 	\begin{attlista}
-		\item underhålla sektionens lokaler, datorer och inventarier
+		\item underhålla sektionens lokaler och inventarier
 		\item handha bokningar av iDét
 		\item hålla minst en Snickerboa per termin
-		\item underhålla sektionens spelmaskiner
 	\end{attlista}
 
 	%%% Togs bort vtm 2018 "resning reglemente" snickerboa bör dock förklaras
@@ -399,26 +399,9 @@ kan sträcka sig över flera år och ska varje år ha en konkret motsvarighet i 
 		\item Källarmästaren
 		\item Vice Källarmästare
 		\item Ljud- och ljusansvarig
-		\item rootmästeriet
 		\item Trädgårdsmästare
         \item Bilansvarig
 		\item Funktionärer
-	\end{itemize}
-
-	\item[\textbf{Rootmästeriet}]
-
-	\item[Åligganden]
-	Det åligger Rootmästeriet
-	\begin{attlista}
-		\item underhålla och förbättra sektionens datorer, dess tillhörande utrustning, programvara och funktioner
-	\end{attlista}
-
-	\item[Sammansättning]
-	Rootmästeriet består av
-	\begin{itemize}
-		\item root
-        \item Vice root
-		\item sudo
 	\end{itemize}
 
 \end{reglemlista}
@@ -507,10 +490,9 @@ Medaljelelekommittén delar ut medaljer till sektionsfunktionärer. Medaljelelek
 	Det åligger Informationsutskottet
 	\begin{attlista}
 		\item utge sektionens medier
-		\item ansvara för sektionens anslagstavlor och websidor
+		\item ansvara för sektionens anslagstavlor
 		\item sända kopior av sektionens publikationer till lämpliga instanser, t~ex övriga sektioner
 		\item upprätthålla sektionens arkiv
-		\item ansvara för sektionens WWW-sidor och att informationen på dessa hålls uppdaterad
 	\end{attlista}
 
 	\item[Sammansättning]
@@ -520,27 +502,10 @@ Medaljelelekommittén delar ut medaljer till sektionsfunktionärer. Medaljelelek
 		\item Vice Informationsansvarig
 		\item Arkivarie
 		\item Artist
-		\item DWWW
 		\item Fotograf
 		\item Filmare
-        \item Redaktör
-		\item Webmaster
+            \item Redaktör
 		\item Funktionärer
-	\end{itemize}
-
-	\item[\textbf{DWWW}]
-
-	\item[Åligganden]
-	Det åligger DWWW
-	\begin{attlista}
-		\item underhålla och utveckla sektionens WWW-sidor
-	\end{attlista}
-
-	\item[Sammansättning]
-	DWWW består av
-	\begin{itemize}
-		\item DWWW-ansvarig
-		\item DWWW-medlem
 	\end{itemize}
 
 \end{reglemlista}
@@ -761,6 +726,27 @@ Medaljelelekommittén delar ut medaljer till sektionsfunktionärer. Medaljelelek
 		\begin{itemize}
 			\item Tackmästare
 			\item Tackmästerister
+		\end{itemize}
+	\end{reglemlista}
+
+\section{Centralprocessutskottet}
+	\begin{reglemlista}
+		\item[Åligganden]
+		Det åligger Centralprocessutskottet
+		\begin{attlista}
+			\item utveckla och underhålla sektionens hemsidor 
+                \item utveckla och underhålla sektionens system, servrar, och vad som hör därtill
+                \item tillgodose övriga programmerings- och teknikprojekt
+		\end{attlista}
+		\item[Sammansättning]
+		Centralprocessutskottet består av
+		\begin{itemize}
+			\item Processmästare
+                \item Vice Processmästare
+                \item DWWW-ansvarig
+                \item root
+                \item Utvecklare
+                \item Funktionärer
 		\end{itemize}
 	\end{reglemlista}
 
@@ -1223,45 +1209,14 @@ ljusutrustning.
 
 %%% funktionar %%%
 \funktionar{DWWW-ansvarig}
-DWWW-ansvarig leder DWWW.
+DWWW-ansvarig underhåller sektionens hemsida.
 
 \begin{reglemlista}
 
 	\item[Åligganden]
 	Det åligger DWWW-ansvarig
 	\begin{attlista}
-		\item leda DWWW
-		\item ansvara för sektionens WWW-sidor
-	\end{attlista}
-
-\end{reglemlista}
-
-%%% funktionar %%%
-\funktionar{DWWW-medlem}
-DWWW-medlem hjälper DWWW-ansvarig med arbetet inom DWWW.
-
-\begin{reglemlista}
-
-	\item[Åligganden]
-	Det åligger DWWW-medlem
-	\begin{attlista}
-		\item hjälpa DWWW-ansvarig med att underhålla och utveckla sektionens WWW-sidor
-	\end{attlista}
-
-\end{reglemlista}
-
-%%% funktionar %%%
-\funktionar{Webmaster}
-% beskrivning saknas
-
-\begin{reglemlista}
-
-	\item[Åligganden]
-	Det åligger Webmaster
-	\begin{attlista}
-		\item tillhandahålla administrativ information på hemsidan, såsom att administrera poster
-		på sektionen
-		\item hjälpa våra medlemmar att använda hemsidan
+		\item agera projektledare för underhåll och utveckling av sektionens webbsidor
 	\end{attlista}
 
 \end{reglemlista}
@@ -1777,31 +1732,13 @@ Revisorerna skall granska sektionens verksamhet och bokslut.
 
 %%% funktionar %%%
 \funktionar{root}
-root leder Rootmästeriet.
-
+root underhåller sektionens datorer och därtill kopplad utrustning.
 \begin{reglemlista}
 
 	\item[Åligganden]
 	Det åligger root
 	\begin{attlista}
-		\item underhålla och förbättra sektionens datorer och därtill kopplad utrustning
-	\end{attlista}
-
-\end{reglemlista}
-
-%%% funktionar %%%
-\funktionar{Vice root}
-
-Vice root hjälper root i dennes
-arbete.
-
-\begin{reglemlista}
-
-	\item[Åligganden]
-	Det åligger Vice root
-	\begin{attlista}
-		\item hjälpa root i dennes arbete
-        \item överta roots funktion i dennes frånvaro
+		\item agera projektledare för underhåll och förbättrande av sektionens datorer och därtill kopplad utrustning
 	\end{attlista}
 
 \end{reglemlista}
@@ -1979,20 +1916,6 @@ Studierådssekreterare för protokoll under studierådetsmöten.
 
 	\item[Val]
 	Studierådssekreteraren väljs av Studierådet
-
-\end{reglemlista}
-
-%%% funktionar %%%
-\funktionar{sudo}
-sudo hjälper root i dennes arbete.
-
-\begin{reglemlista}
-
-	\item[Åligganden]
-	Det åligger sudo
-	\begin{attlista}
-		\item hjälpa root i dennes arbete
-	\end{attlista}
 
 \end{reglemlista}
 
@@ -2353,6 +2276,42 @@ Tackmästaren ansvarar för att leda Tackmästeriet.
       \end{itemize}
 \end{reglemlista}
 
+%%% funktionar %%%
+\funktionar{Processmästare}
+Processmästaren ansvarar för att leda Centralprocessutskottet och administrera sektionens hemsida.
+\begin{reglemlista}
+	\item[Åligganden]
+        Det åligger Processmästaren	
+        \begin{attlista}
+		\item leda och fördela arbetet inom utskottet
+            \item tillhandahålla administrativ information på hemsidan, såsom att administrera poster på sektionen
+            \item hjälpa våra medlemmar att använda hemsidan
+	\end{attlista}
+\end{reglemlista}
+
+%%% funktionar %%%
+\funktionar{Vice Processmästare}
+Vice Processmästaren hjälper Processmästaren i dennes arbete.
+\begin{reglemlista}
+	\item[Åligganden]
+        Det åligger Vice Processmästaren	
+        \begin{attlista}
+		\item hjälpa DWWW-ansvarig och root i deras arbete
+            \item att vägleda funktionärer och övriga sektionsmedlemmar i projekt och uppgifter inom Centralprocessutskottet 
+	\end{attlista}
+\end{reglemlista}
+
+%%% funktionar %%%
+\funktionar{Utvecklare}
+Utvecklarna hjälper utskottet i dess åligganden.
+\begin{reglemlista}
+	\item[Åligganden]
+        Det åligger Utvecklarna	
+        \begin{attlista}
+		\item hjälpa DWWW-ansvarig och root i deras arbete
+            \item vägleda funktionärer och övriga sektionsmedlemmar i projekt och uppgifter inom  Centralprocessutskottet
+	\end{attlista}
+\end{reglemlista}
 
 %%%%%%%%%%%%% SECTION %%%%%%%%%%%%%
 \section{Medaljer}

--- a/stadgar/stadgar.tex
+++ b/stadgar/stadgar.tex
@@ -579,8 +579,9 @@ Sektionens utskott är:
 \item Nollningsutskottet,
 \item Medaljelelekommittén,
 \item Trivselrådet,
-\item Framtidsutskottet, samt
-\item Tackmästeriet.
+\item Framtidsutskottet,
+\item Tackmästeriet, samt
+\item Centralprocessutskottet.
 \end{enumerate}
 
 \paragraf{14.2}{Åligganden}
@@ -614,7 +615,7 @@ sammanhang.
 
 \paragraf{14.8}{Källarmästeriet}
 
-Källarmästeriet har till uppgift att tillgodose sektionsmedlemmarnas intressen i frågor om underhåll av sektionens lokaler, sektionens datorer samt vad därmed äger sammanhang.
+Källarmästeriet har till uppgift att tillgodose sektionsmedlemmarnas intressen i frågor om underhåll av sektionens lokaler samt vad därmed äger sammanhang.
 
 \paragraf{14.9}{Aktivitetsutskottet}
 
@@ -625,17 +626,17 @@ av nöjen och förströelser samt vad därmed äger sammanhang.
 
 Nollningsutskottet har till uppgift att genomföra nollning samt vad därmed äger sammanhang.
 
-\paragraf{14.11}{ Sexmästeriet}
+\paragraf{14.11}{Sexmästeriet}
 
 Sexmästeriet har till uppgift att tillgodose sektionsmedlemmarnas intressen
 vad gäller festaktivitet samt vad därmed äger sammanhang.
 
-\paragraf{14.12}{ Medaljelelekommittén}
+\paragraf{14.12}{Medaljelelekommittén}
 
 Medaljelelekommittén har till uppgift att dela ut medaljer till
 sektionsfunktionärer.
 
-\paragraf{14.13}{ Trivselrådet}
+\paragraf{14.13}{Trivselrådet}
 
 Trivselrådet har till uppgift att organisera och se över sektionens likabehandlings-, internationaliserings- samt arbetsmiljöarbete.
 
@@ -647,7 +648,13 @@ Framtidsutskottet har som uppgift att stödja sektionen i dess strategiska arbet
 
 Tackmästeriet har som uppgift att planera och genomföra sektionsgemensamma tackevenemang.
 
-\paragraf{14.16}{ Alternativ titulering}
+\paragraf{14.16}{Centralprocessutskottet}
+
+Centralprocessutskottet har till uppgift att underhålla sektionens
+hemsidor, mjukvara och hårdvara, att tillgodose sektionsmedlemmarnas intressen vad gäller programmering och teknik samt
+vad därmed äger sammanhang.
+
+\paragraf{14.17}{Alternativ titulering}
 
 Alternativ titulering för utskott är mästeri.
 

--- a/stadgar/stadgar.tex
+++ b/stadgar/stadgar.tex
@@ -453,8 +453,13 @@ Beslut fattas genom acklamation, såvida votering ej begärts.
 Votering skall vara sluten vid personval. I alla övriga fall skall öppen
 votering hållas. Om så begärs skall vid öppen votering föras röstprotokoll.
 Sluten votering sker efter namnupprop. Om röstetalet är lika äger
-mötesordförande utslagsröst vid öppen votering, vid sluten votering avgör
-lotten.
+mötesordförande utslagsröst vid öppen votering.
+
+Vid sluten votering där det finns fler än två kandidater som kandiderar för samma post, 
+och två av dem erhåller samma röstantal, samt att båda enligt kårens stadgar inte kan gå 
+vidare till nästa röstomgång, ska ett nytt slutet personval etableras mellan de kandidater
+som fick samma mängd röster. Därefter ska det röstas om vilken av de kandidater som ska få 
+behålla sin plats i det ursprungliga valet.
 
 \paragraf{11.5}{Adjungerade}
 


### PR DESCRIPTION
Under HTM-Val 2024 röstades även två **andra läsningar** igenom, _**Programmästeriet (Centralprocessutskottet)**_ och _**Sloppa lotten vid sluten votering**_. Dessa förändringar ska nu reflekteras i styrdokumenten.

Införande av CPU påverkade: Stadgarna, Reglementet och Policy för Tackverksamhet
Sloppa lotten vid sluten votering påverkade: Stadgarna

OBS många ändringar för CPU och därav ber jag om extra översyn vid godkännande.